### PR TITLE
build: enable typescript generation in rspack config

### DIFF
--- a/apps/app/rspack.config.js
+++ b/apps/app/rspack.config.js
@@ -1,5 +1,6 @@
 const rspack = require('@rspack/core');
 const isDev = process.env.NODE_ENV === 'development';
+const emitTypes = process.env.DTS === 'true';
 const refreshPlugin = require('@rspack/plugin-react-refresh');
 
 const path = require('path');
@@ -86,7 +87,7 @@ const config = {
     }),
     new ModuleFederationPlugin({
       name,
-      dts: false,
+      dts: emitTypes,
       filename: 'remoteEntry.js',
       shared: {
         react: {

--- a/apps/checkout-cart/rspack.config.js
+++ b/apps/checkout-cart/rspack.config.js
@@ -1,5 +1,6 @@
 const rspack = require('@rspack/core');
 const isDev = process.env.NODE_ENV === 'development';
+const emitTypes = process.env.DTS === 'true';
 const refreshPlugin = require('@rspack/plugin-react-refresh');
 
 const path = require('path');
@@ -85,7 +86,7 @@ const config = {
     }),
     new ModuleFederationPlugin({
       name,
-      dts: false,
+      dts: emitTypes,
       filename: 'remoteEntry.js',
       shared: {
         react: {

--- a/apps/checkout/rspack.config.js
+++ b/apps/checkout/rspack.config.js
@@ -1,5 +1,6 @@
 const rspack = require('@rspack/core');
 const isDev = process.env.NODE_ENV === 'development';
+const emitTypes = process.env.DTS === 'true';
 const refreshPlugin = require('@rspack/plugin-react-refresh');
 
 const path = require('path');
@@ -85,7 +86,7 @@ const config = {
     }),
     new ModuleFederationPlugin({
       name,
-      dts: false,
+      dts: emitTypes,
       filename: 'remoteEntry.js',
       shared: {
         react: {

--- a/apps/decide/rspack.config.js
+++ b/apps/decide/rspack.config.js
@@ -1,5 +1,6 @@
 const rspack = require('@rspack/core');
 const isDev = process.env.NODE_ENV === 'development';
+const emitTypes = process.env.DTS === 'true';
 const refreshPlugin = require('@rspack/plugin-react-refresh');
 
 const path = require('path');
@@ -85,7 +86,7 @@ const config = {
     }),
     new ModuleFederationPlugin({
       name,
-      dts: false,
+      dts: emitTypes,
       filename: 'remoteEntry.js',
       shared: {
         react: {

--- a/apps/explore/rspack.config.js
+++ b/apps/explore/rspack.config.js
@@ -1,5 +1,6 @@
 const rspack = require('@rspack/core');
 const isDev = process.env.NODE_ENV === 'development';
+const emitTypes = process.env.DTS === 'true';
 const refreshPlugin = require('@rspack/plugin-react-refresh');
 
 const path = require('path');
@@ -86,7 +87,7 @@ const config = {
     new ModuleFederationPlugin({
       name,
       filename: 'remoteEntry.js',
-      dts: false,
+      dts: emitTypes,
       shared: {
         react: {
           singleton: true,


### PR DESCRIPTION
# Enable typescript generation from rspack build

This PR enables typescript generation from an rspack build. It provides type hints for remote imports and helps to catch contract violations during build.

## Generating types
The generated types are emitted to the `@mf-types` folder in the root directory of each remote, but the output is not in SCM. In a team setup, this is the preferred way to manage type definitions across remotes, as the types are downloaded at runtime, which guarantees they're synced without requiring any additional steps. 

To generate types, we should build & serve the applications with the environment variable `DTS` loaded: 

```bash
DTS=true pnpm build
DTS=true pnpm serve
```

By running the commands above, a `@mf-types` dir is created for each consumer app, including their remote type definitions. This environment variable can be used to update types during development.